### PR TITLE
Fix toast notifications to display in top-right corner

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,6 @@
 <template>
   <NuxtLayout>
     <NuxtPage />
+    <UNotifications />
   </NuxtLayout>
 </template>

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,12 @@
 <template>
   <NuxtLayout>
     <NuxtPage />
-    <UNotifications :ui="{ wrapper: 'fixed flex flex-col justify-start z-[55]', position: 'top-0 end-0', width: 'w-full sm:w-96' }" />
+    <UNotifications
+      :ui="{
+        wrapper: 'fixed flex flex-col justify-start z-[55]',
+        position: 'top-0 end-0',
+        width: 'w-full sm:w-96',
+      }"
+    />
   </NuxtLayout>
 </template>

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLayout>
     <NuxtPage />
-    <UNotifications position="top-right" />
+    <UNotifications :ui="{ wrapper: 'fixed flex flex-col justify-start z-[55]', position: 'top-0 end-0', width: 'w-full sm:w-96' }" />
   </NuxtLayout>
 </template>

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLayout>
     <NuxtPage />
-    <UNotifications />
+    <UNotifications position="top-right" />
   </NuxtLayout>
 </template>

--- a/composables/useNotification.ts
+++ b/composables/useNotification.ts
@@ -10,17 +10,42 @@ export interface ToastOptions {
 }
 
 export const useNotification = () => {
+  const toast = useToast()
+
   const showNotification = (message: string, type: ToastType = 'info', options?: ToastOptions) => {
-    // Simple console logging for now - in a real app you'd integrate with a toast library
-    const timestamp = new Date().toLocaleTimeString()
-    console.log(`[${timestamp}] ${type.toUpperCase()}: ${message}`, options)
-    
-    // You could integrate with libraries like:
-    // - @vueuse/core notifications
-    // - vue-toastification
-    // - Custom toast component
-    
-    return { id: Date.now().toString() }
+    const toastConfig = {
+      title: options?.title,
+      description: message,
+      timeout: options?.duration || 5000,
+    }
+
+    switch (type) {
+      case 'success':
+        return toast.add({
+          ...toastConfig,
+          color: 'green',
+          icon: 'i-heroicons-check-circle',
+        })
+      case 'error':
+        return toast.add({
+          ...toastConfig,
+          color: 'red',
+          icon: 'i-heroicons-x-circle',
+        })
+      case 'warning':
+        return toast.add({
+          ...toastConfig,
+          color: 'yellow',
+          icon: 'i-heroicons-exclamation-triangle',
+        })
+      case 'info':
+      default:
+        return toast.add({
+          ...toastConfig,
+          color: 'blue',
+          icon: 'i-heroicons-information-circle',
+        })
+    }
   }
 
   const showSuccess = (message: string, options?: ToastOptions) => {


### PR DESCRIPTION
## Purpose
Users reported that toast notifications were not working properly and were appearing in the bottom right corner instead of the desired top-right corner. This PR addresses the positioning issue to ensure toasts display correctly in the top-right corner as requested.

## Code changes
- **Added UNotifications component** to `app.vue` with custom positioning configuration to display toasts in the top-right corner
- **Implemented proper toast functionality** in `useNotification.ts` composable by integrating with Nuxt UI's `useToast()` instead of console logging
- **Added toast styling** with appropriate colors and icons for different notification types (success, error, warning, info)
- **Configured toast positioning** with `top-0 end-0` classes and responsive width settings

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5642a72b52cd4c1188667191d70685e6/pixel-works)

👀 [Preview Link](https://5642a72b52cd4c1188667191d70685e6-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5642a72b52cd4c1188667191d70685e6</projectId>-->
<!--<branchName>pixel-works</branchName>-->